### PR TITLE
Change defaults for module 2 plot

### DIFF
--- a/R/ui.R
+++ b/R/ui.R
@@ -134,14 +134,14 @@ ui_call <- function() {
                                 "Missing data treatment",
                                 multiple = TRUE,
                                 choices = levels(estimates$method),
-                                selected = levels(estimates$method)
+                                selected = levels(estimates$method)[1:2]
                             ),
                             shiny::selectInput(
                                 "outcome",
                                 "Outcome measure",
                                 multiple = TRUE,
                                 choices = levels(estimates$variable)[-1],
-                                selected = c("estimate", "t", "fmi")
+                                selected = levels(estimates$variable)[c(2:5, 10)]
                             ),
                             shiny::checkboxGroupInput(
                                 "term",


### PR DESCRIPTION
- get rid of CC as default method for improve readability and storytelling
- use estiamtes ubar, b, and t as default outcome measures
- get rid of FMI as outcome measure